### PR TITLE
saveNetworkStructureXML now takes 8 arguments instead of 7.

### DIFF
--- a/CElegans/pythonScripts/GenerateNeuroML.py
+++ b/CElegans/pythonScripts/GenerateNeuroML.py
@@ -1,4 +1,3 @@
-
 #
 #
 #   A file which opens the CElegans neuroConstruct project, and saves generated network in NeuroML format
@@ -67,7 +66,8 @@ NeuroMLFileManager.saveNetworkStructureXML(project,
                                        False,
                                        simConfig.getName(),
                                        "Physiological Units",
-                                       NeuroMLConstants.NeuroMLVersion.NEUROML_VERSION_1);
+                                       NeuroMLConstants.NeuroMLVersion.NEUROML_VERSION_1,
+                                       None);
 
 nmlFileName = "GeneratedNeuroML2.xml"
 
@@ -77,7 +77,8 @@ NeuroMLFileManager.saveNetworkStructureXML(project,
                                        False,
                                        simConfig.getName(),
                                        "Physiological Units",
-                                       NeuroMLConstants.NeuroMLVersion.NEUROML_VERSION_2_BETA);
+                                       NeuroMLConstants.NeuroMLVersion.NEUROML_VERSION_2_BETA,
+                                       None);
 
 
 print "Done!"


### PR DESCRIPTION
The command "~/neuroConstruct/nC.sh -python GenerateNeuroML.py" fails with the error:
TypeError: saveNetworkStructureXML(): expected 8 args; got 7

Since 2013-10-30, saveNetworkStructureXML in neuroConstruct's NeuroMLFileManager.java takes an 8th argument: filesToInclude. This is an optional feature, so if we set it to a null value we get equivalent XML output to before.
